### PR TITLE
Add setting to enable Favorites collections

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -10,13 +10,14 @@ BOOL autoPlayNextVideo;
 BOOL changeRegion;
 BOOL showProgressBar;
 BOOL canHideUI;
+BOOL enableFavoritesCollections;
 BOOL showAdditionalDownloadButton;
 NSDictionary *region;
 
 static void reloadPrefs() {
   NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:@PLIST_PATH] ?: @{
     @"noads": @YES,
-    @"downloadWithoutWatermark", @YES,
+    @"downloadWithoutWatermark": @YES,
     @"canHideUI": @YES,
   };
 
@@ -26,6 +27,7 @@ static void reloadPrefs() {
   changeRegion = settings[@"changeRegion"];
   region = settings[@"region"];
   showProgressBar = settings[@"showProgressBar"];
+  enableFavoritesCollections = settings[@"enableFavoritesCollections"];
   canHideUI = settings[@"canHideUI"];
 }
 
@@ -164,6 +166,16 @@ static void reloadPrefs() {
 
       afcVC.tabControl.hidden = afcVC.isUIHidden;
       afcVC.specialEventEntranceView.hidden = afcVC.isUIHidden;
+    }
+  %end
+  
+  %hook AWEFavoriteAwemeViewController
+    - (id)init {
+      if (enableFavoritesCollections) {
+        return [%c(TTKFavoriteAwemeCollectionsViewController) new];
+      } else {
+        return %orig;
+      }
     }
   %end
 %end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -14,15 +14,19 @@ BOOL showAdditionalDownloadButton;
 NSDictionary *region;
 
 static void reloadPrefs() {
-  NSDictionary *settings = [[NSMutableDictionary alloc] initWithContentsOfFile:@PLIST_PATH] ?: [@{} mutableCopy];
+  NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:@PLIST_PATH] ?: @{
+    @"noads": @YES,
+    @"downloadWithoutWatermark", @YES,
+    @"canHideUI": @YES,
+  };
 
-  noads = [[settings objectForKey:@"noads"] ?: @(YES) boolValue];
-  downloadWithoutWatermark = [[settings objectForKey:@"downloadWithoutWatermark"] ?: @(YES) boolValue];
-  autoPlayNextVideo = [[settings objectForKey:@"autoPlayNextVideo"] ?: @(NO) boolValue];
-  changeRegion = [[settings objectForKey:@"changeRegion"] ?: @(NO) boolValue];
-  region = [settings objectForKey:@"region"] ?: [@{} mutableCopy];
-  showProgressBar = [[settings objectForKey:@"showProgressBar"] ?: @(NO) boolValue];
-  canHideUI = [[settings objectForKey:@"canHideUI"] ?: @(YES) boolValue];
+  noads = settings[@"noads"];
+  downloadWithoutWatermark = settings[@"downloadWithoutWatermark"];
+  autoPlayNextVideo = settings[@"autoPlayNextVideo"];
+  changeRegion = settings[@"changeRegion"];
+  region = settings[@"region"];
+  showProgressBar = settings[@"showProgressBar"];
+  canHideUI = settings[@"canHideUI"];
 }
 
 %group CoreLogic

--- a/pref/Resources/Root.plist
+++ b/pref/Resources/Root.plist
@@ -108,6 +108,23 @@
         <key>PostNotification</key>
         <string>com.haoict.tiktokgodpref/PrefChanged</string>
       </dict>
+      
+      <dict>
+        <key>cell</key>
+        <string>PSSwitchCell</string>
+        <key>cellClass</key>
+        <string>HPSSwitchCell</string>
+        <key>default</key>
+        <false />
+        <key>defaults</key>
+        <string>com.haoict.tiktokgodpref</string>
+        <key>key</key>
+        <string>enableFavoritesCollections</string>
+        <key>label</key>
+        <string>ENABLE_FAV_COLLECTIONS</string>
+        <key>PostNotification</key>
+        <string>com.haoict.tiktokgodpref/PrefChanged</string>
+      </dict>
 
       <dict>
         <key>cell</key>

--- a/pref/Resources/ar.lproj/Root.strings
+++ b/pref/Resources/ar.lproj/Root.strings
@@ -21,6 +21,7 @@
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "للتقديم السريع أو الإرجاع للفيديو";
   "CAN_HIDE_UI" = "يمكن إخفاء واجهة المستخدم";
   "ENABLE_SHOW_HIDE_UI_BUTTON" = "تمكين زر إظهار / إخفاء واجهة المستخدم";
+  "ENABLE_FAV_COLLECTIONS" = "تمكين مجموعات المفضلة";
   "MORE_FEATURES_COMMING_SOON" = "المزيد من الميزات قريبا";
   "OTHER_PREFERENCES" = "تفضيلات أخرى";
   "SHOW_TOP_RIGHT_CORNER_DOWNLOAD_BUTTON" = "إظهار زر تنزيل الزاوية اليمنى العلوية";

--- a/pref/Resources/base.lproj/Root.strings
+++ b/pref/Resources/base.lproj/Root.strings
@@ -15,12 +15,13 @@
   "FINGER_FREE" = "Finger free, yeah!";
   "CHANGE_REGION" = "Change Region";
   "VIEW_TIKTOK_FROM_ANOTHER_COUNTRY" = "View TikTok from another country";
-  "MAY_NOT_WORK_FOR_IPAD_AND_SOME_DEVICES" = "(may not work for iPad and some devices";
+  "MAY_NOT_WORK_FOR_IPAD_AND_SOME_DEVICES" = "(may not work for iPad and some devices)";
   "SELECT_COUNTRY" = "Select Country";
   "SHOW_PROGRESS_BAR" = "Show progress bar";
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "For fast forward or rewind video";
   "CAN_HIDE_UI" = "Can hide UI";
   "ENABLE_SHOW_HIDE_UI_BUTTON" = "Enable Show/Hide UI button";
+  "ENABLE_FAV_COLLECTIONS" = "Enable Favorites Collections";
   "MORE_FEATURES_COMMING_SOON" = "More Features Comming Soon";
   "OTHER_PREFERENCES" = "Other Preferences";
   "SHOW_TOP_RIGHT_CORNER_DOWNLOAD_BUTTON" = "Show Top Right Corner Download Button";

--- a/pref/Resources/de.lproj/Root.strings
+++ b/pref/Resources/de.lproj/Root.strings
@@ -12,6 +12,7 @@
 "DOWNLOAD_WITHOUT_WATERMARK" = "Ohne Wasserzeichen laden";
 "DO_YOU_REALLY_WANT_TO_KILL_TIKTOK" = "Willst du TikTok wirklich neu laden?";
 "ENABLE_SHOW_HIDE_UI_BUTTON" = "UI-Schaltfläche ein\/aus aktivieren";
+"ENABLE_FAV_COLLECTIONS" = "Favoritensammlungen aktivieren";
 "FEATURE_REQUEST" = "Erweiterung anfragen ✨";
 "FINGER_FREE" = "Finger frei, ja!";
 "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "Zum schnellen Vor- oder Zurückspulen";

--- a/pref/Resources/en.lproj/Root.strings
+++ b/pref/Resources/en.lproj/Root.strings
@@ -21,6 +21,7 @@
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "For fast forward or rewind video";
   "CAN_HIDE_UI" = "Can hide UI";
   "ENABLE_SHOW_HIDE_UI_BUTTON" = "Enable Show/Hide UI button";
+  "ENABLE_FAV_COLLECTIONS" = "Enable Favorites Collections";
   "MORE_FEATURES_COMMING_SOON" = "More Features Comming Soon";
   "OTHER_PREFERENCES" = "Other Preferences";
   "SHOW_TOP_RIGHT_CORNER_DOWNLOAD_BUTTON" = "Show Top Right Corner Download Button";

--- a/pref/Resources/th.lproj/Root.strings
+++ b/pref/Resources/th.lproj/Root.strings
@@ -21,6 +21,7 @@
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "เพื่อให้สามารถกรอวิดีโอไปข้างหน้าหรือถอยกลับได้";
   "CAN_HIDE_UI" = "ซ่อน UI ได้";
   "ENABLE_SHOW_HIDE_UI_BUTTON" = "เปิดใช้งาน ซ่อน/แสดงปุ่ม UI (แผงเมนูต่าง ๆ ในหน้าเล่นวิดีโอ)";
+  "ENABLE_FAV_COLLECTIONS" = "เปิดใช้งานคอลเลกชั่นรายการโปรด";
   "MORE_FEATURES_COMMING_SOON" = "ฟีเจอร์เพิ่มเติมกำลังจะมาเร็ว ๆ นี้";
   "OTHER_PREFERENCES" = "ตั้งค่าอื่น ๆ";
   "SHOW_TOP_RIGHT_CORNER_DOWNLOAD_BUTTON" = "แสดงปุ่มดาวน์โหลดมุมขวาด้านบนของแอป";

--- a/pref/Resources/tr.lproj/Root.strings
+++ b/pref/Resources/tr.lproj/Root.strings
@@ -12,6 +12,7 @@
   "DOWNLOAD_WITHOUT_WATERMARK"="Filigran olmadan indir";
   "DO_YOU_REALLY_WANT_TO_KILL_TIKTOK"="Gerçekten ayarları uygulamak istiyor musun?";
   "ENABLE_SHOW_HIDE_UI_BUTTON"="Gösteriyi Göster\/Gizle UI düğmesini";
+  "ENABLE_FAV_COLLECTIONS" = "Favori Koleksiyonlarını Etkinleştir";
   "FEATURE_REQUEST"="Özellik isteği Sparkles";
   "FINGER_FREE"="Finger free, yeah!";
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO"="Hızlı ileri veya geri sarma videosu için";

--- a/pref/Resources/vi.lproj/Root.strings
+++ b/pref/Resources/vi.lproj/Root.strings
@@ -21,6 +21,7 @@
   "FOR_FAST_FORWARD_OR_REWIND_VIDEO" = "Dùng để tua nhanh hoặc tua ngược video";
   "CAN_HIDE_UI" = "Có thể ẩn UI";
   "ENABLE_SHOW_HIDE_UI_BUTTON" = "Mở chức nút năng ẩn/hiện UI";
+  "ENABLE_FAV_COLLECTIONS" = "Bật Bộ sưu tập Yêu thích";
   "MORE_FEATURES_COMMING_SOON" = "Nhiều tính năng mới sẽ cập nhật sau";
   "OTHER_PREFERENCES" = "Tùy chỉnh phụ";
   "SHOW_TOP_RIGHT_CORNER_DOWNLOAD_BUTTON" = "Hiện nút download ở góc trên bên phải";


### PR DESCRIPTION
This enables the "collections" feature for organizing your Favorited videos. It has not yet rolled out to all users for some reason, but it's really useful.

This also cleans up the preferences code in `Tweak.xm` a little. `settings` dict did not need to be mutable, and defaults can be supplied within the trailing dictionary literal instead of using the ternary operator. `region` should also just be `nil` instead of `@{}`; they will behave the same.

I did translations with Google Translate, I hope that's okay