### PR TITLE
added the ability to get full share link

### DIFF
--- a/Tweak.h
+++ b/Tweak.h
@@ -61,3 +61,7 @@
 @interface AWEFeedTableViewController : UIViewController
 - (void)scrollToNextVideo;
 @end
+
+@interface AWEShareLinkModel
+-(NSString *)parsedURL:(NSString *)fullURL;
+@end

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -173,6 +173,31 @@ static AWEFeedContainerViewController *__weak sharedInstance;
     }
 }
 %end
+
+%hook AWEShareLinkModel
+NSString* fullURLShared;
+-(void)setTextForCopy:(id)arg1 {
+	if ([(NSString*)arg1 containsString:@"@"]) {
+		fullURLShared = [self parsedURL:arg1];
+	}
+	%orig(fullURLShared);
+}
+
+%new
+-(NSString *)parsedURL:(NSString *)fullURL {
+	
+	NSRange  searchedRange = NSMakeRange(0, [fullURL length]);
+	NSString *pattern = @"(.+?(?=\\\?))";
+	NSError  *error = nil;
+	NSRegularExpression* regex = [NSRegularExpression regularExpressionWithPattern: pattern options:0 error:&error];
+	NSArray* matches = [regex matchesInString:fullURL options:0 range: searchedRange];
+	for (NSTextCheckingResult* match in matches) {
+		NSRange group1 = [match rangeAtIndex:1];
+		return [fullURL substringWithRange:group1];
+	}
+	return nil;
+}
+%end
 %end
 
 %ctor {

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.haoict.tiktokgod
 Name: TikTok God
 Depends: mobilesubstrate, preferenceloader, com.haoict.libhdev (>= 4.8.1), firmware (>= 12)
-Version: 3.0.0
+Version: 3.0.1
 Architecture: iphoneos-arm
 Description: The best tweak for TikTok app.
  The best tweak for TikTok app.
@@ -16,6 +16,7 @@ Description: The best tweak for TikTok app.
  - Can hide UI (view video in full screen)
  - Bypass jailbreak detection (make like and follow work)
  - Support iOS 12 - 14 & latest TikTok version
+ - Getting direct URL when pressing on Copy Link
  . 
  I work very hard to make good, free and open source tweaks for everyone
  If you want to support, you can buy me a coffee at https://www.paypal.me/haoict


### PR DESCRIPTION
When pressing on copy link, we will get the full URL instead the short one tiktok was generating.

requested in comment https://www.reddit.com/r/TweakBounty/comments/vc81sd/comment/icoutt8/?utm_source=share&utm_medium=web2x&context=3

after bounty was completed